### PR TITLE
WIP ASL Letters speed increase 

### DIFF
--- a/ImageClassification/ViewControllers/CameraBoard.swift
+++ b/ImageClassification/ViewControllers/CameraBoard.swift
@@ -150,10 +150,13 @@ extension CameraBoard: CameraFeedManagerDelegate {
 	}
 	
 	func didOutput(pixelBuffer: CVPixelBuffer) {
-//        let currentTimeMs = Date().timeIntervalSince1970 * 1000
-//        guard (currentTimeMs - previousInferenceTimeMs) >= delayBetweenInferencesMs else { return }
-//        previousInferenceTimeMs = currentTimeMs
-
+		// This block of code set a delay between inferences.
+		/*
+        let currentTimeMs = Date().timeIntervalSince1970 * 1000
+        guard (currentTimeMs - previousInferenceTimeMs) >= delayBetweenInferencesMs else { return }
+        previousInferenceTimeMs = currentTimeMs
+		*/
+		
         // Pass the pixel buffer to TensorFlow Lite to perform inference.
         result = modelDataHandler?.runModel(onFrame: pixelBuffer)
 		DispatchQueue.main.async {

--- a/ImageClassification/ViewControllers/CameraBoard.swift
+++ b/ImageClassification/ViewControllers/CameraBoard.swift
@@ -182,6 +182,7 @@ extension CameraBoard: CameraFeedManagerDelegate {
 			default:
 				let confidence = self.result!.inferences[0].confidence
 				let prediction: String = self.result!.inferences[0].label.description
+				// check confidence and reoccurence here before inserting into textview.
 				self.checkConfidenceAndReoccurrenceOfLetter(prediction, confidence)
 			}
 		}

--- a/ImageClassification/ViewControllers/CameraBoard.swift
+++ b/ImageClassification/ViewControllers/CameraBoard.swift
@@ -21,10 +21,10 @@ class CameraBoard: UIView {
     var predictionButton = [UIButton]()
     let predictionStack = UIStackView()
     var stringCache = String()
-	
+
 	//Viet inspired variables
 	/// The lastLetter predicted.
-	var lastLetter:String?
+	var lastLetter: String?
 	/// Space, del, or nothing predicted.
 	var lastNonLetter: String?
 	/// The number of times a letter reoccured in a prediction
@@ -35,7 +35,7 @@ class CameraBoard: UIView {
 	let minimumConfidence: Float = 0.89
 	/// the minimum number of reoccurrence is a letter needed to be inserted into the text view
 	let minimumReoccurence: Int = 1
-	
+
     var prediction = ["", "", ""]
     //var prediction = Array<String>()
 	weak var target: UIKeyInput?
@@ -116,24 +116,24 @@ extension CameraBoard: CameraFeedManagerDelegate {
 	//Temporary functions
 	/// This is a temporary function to visualize that delete is being predicted.
 	fileprivate func setPredictionToDelete() {
-		for button in predictionButton{
+		for button in predictionButton {
 			button.setTitle("delete", for: .normal)
 		}
 	}
-	
+
 	/// This is a temporary function to visualize that space was predicted.
 	fileprivate func setPredictiontoSpace() {
-		for button in predictionButton{
+		for button in predictionButton {
 			button.setTitle("space", for: .normal)
 		}
 	}
 	/// This may or may not be a temporary function to clear the prediction buttons to an empty string.
 	fileprivate func setPredictionToNothing() {
-		for button in predictionButton{
+		for button in predictionButton {
 			button.setTitle("", for: .normal)
 		}
 	}
-	
+
 	/// Function that checks the letter result from the model. If the prediction occurs more than the `reoccurenceConstant` the prediction is inserted into the TextView.
 	/// - Parameters:
 	///   - prediction: The topmost prediction from the model.
@@ -141,9 +141,9 @@ extension CameraBoard: CameraFeedManagerDelegate {
 	fileprivate func checkConfidenceAndReoccurrenceOfLetter(_ prediction: String, _ confidence: Float) {
 		if prediction == self.lastLetter && confidence > self.minimumConfidence {
 			//					print(prediction)
-			
+
 			self.showPredictionLetterInStack(prediction, confidence, self.recurCount)
-			
+
 			self.recurCount += 1
 		} else {
 			self.lastLetter = prediction
@@ -157,7 +157,7 @@ extension CameraBoard: CameraFeedManagerDelegate {
 			self.setPredictionToNothing()
 		}
 	}
-	
+
 	func didOutput(pixelBuffer: CVPixelBuffer) {
 		// This block of code set a delay between inferences.
 		/*
@@ -165,7 +165,7 @@ extension CameraBoard: CameraFeedManagerDelegate {
         guard (currentTimeMs - previousInferenceTimeMs) >= delayBetweenInferencesMs else { return }
         previousInferenceTimeMs = currentTimeMs
 		*/
-		
+
         // Pass the pixel buffer to TensorFlow Lite to perform inference.
         result = modelDataHandler?.runModel(onFrame: pixelBuffer)
 		DispatchQueue.main.async {

--- a/ImageClassification/ViewControllers/CameraBoard.swift
+++ b/ImageClassification/ViewControllers/CameraBoard.swift
@@ -92,7 +92,7 @@ class CameraBoard: UIView {
 }
 
 extension CameraBoard: CameraFeedManagerDelegate {
-	/// This is a temporary function to visualize the current letter being predicted, and show the confidence associated. The letter predicted is shown on the prediction buttons at the specific button index associated to count. If count is greater than the numebr of buttons, the prediction is not shown to avoid Segfault. 
+	/// This is a temporary function to visualize the current letter being predicted, and show the confidence associated. The letter predicted is shown on the prediction buttons at the specific button index associated to count. If count is greater than the numebr of buttons, the prediction is not shown to avoid Segfault.
 	/// - Parameters:
 	///   - prediction: The current prediction from the model
 	///   - confidence: The confidence value associated
@@ -107,23 +107,22 @@ extension CameraBoard: CameraFeedManagerDelegate {
 	//Temporary functions
 	/// This is a temporary function to visualize that delete is being predicted.
 	fileprivate func setPredictionToDelete() {
-		self.predictionButton[0].setTitle("delete", for: .normal)
-		self.predictionButton[1].setTitle("delete", for: .normal)
-		self.predictionButton[2].setTitle("delete", for: .normal)
+		for button in predictionButton{
+			button.setTitle("delete", for: .normal)
+		}
 	}
 	
 	/// This is a temporary function to visualize that space was predicted.
 	fileprivate func setPredictiontoSpace() {
-		//                self.stringCache.removeAll()
-		self.predictionButton[0].setTitle("space", for: .normal)
-		self.predictionButton[1].setTitle("space", for: .normal)
-		self.predictionButton[2].setTitle("space", for: .normal)
+		for button in predictionButton{
+			button.setTitle("space", for: .normal)
+		}
 	}
 	/// This may or may not be a temporary function to clear the prediction buttons to an empty string.
 	fileprivate func setPredictionToNothing() {
-		self.predictionButton[0].setTitle("", for: .normal)
-		self.predictionButton[1].setTitle("", for: .normal)
-		self.predictionButton[2].setTitle("", for: .normal)
+		for button in predictionButton{
+			button.setTitle("", for: .normal)
+		}
 	}
 	
 	/// Function that checks the letter result from the model. If the prediction occurs more than the `reoccurenceConstant` the prediction is inserted into the TextView.

--- a/ImageClassification/ViewControllers/CameraBoard.swift
+++ b/ImageClassification/ViewControllers/CameraBoard.swift
@@ -21,12 +21,21 @@ class CameraBoard: UIView {
     var predictionButton = [UIButton]()
     let predictionStack = UIStackView()
     var stringCache = String()
+	
 	//Viet inspired variables
-	var lastLetter, lastNonLetter: String?
+	/// The lastLetter predicted.
+	var lastLetter:String?
+	/// Space, del, or nothing predicted.
+	var lastNonLetter: String?
+	/// The number of times a letter reoccured in a prediction
 	var recurCount = 0
+	/// The number of times a nonLetter (Space, del, or nothing) were predicted.
 	var recurCountNonLetter = 0
+	/// the minimum confidence value needed to be inserted into the text view
 	let minimumConfidence: Float = 0.89
-	let reoccurenceConstant: Int = 1
+	/// the minimum number of reoccurrence is a letter needed to be inserted into the text view
+	let minimumReoccurence: Int = 1
+	
     var prediction = ["", "", ""]
     //var prediction = Array<String>()
 	weak var target: UIKeyInput?
@@ -142,7 +151,7 @@ extension CameraBoard: CameraFeedManagerDelegate {
 			self.setPredictionToNothing()
 			self.recurCount = 0
 		}
-		if self.recurCount > reoccurenceConstant {
+		if self.recurCount > minimumReoccurence {
 			self.target?.insertText(self.lastLetter!)
 			self.recurCount = 0
 			self.setPredictionToNothing()

--- a/ImageClassification/ViewControllers/ViewController.swift
+++ b/ImageClassification/ViewControllers/ViewController.swift
@@ -71,7 +71,7 @@ class ViewController: UIViewController {
 	var recurCount = 0
 	var recurCountNonLetter = 0
 	let minimumConfidence: Float = 0.89
-	
+
     // MARK: Controllers that manage functionality
     // Handles all the camera related functionality
     private lazy var cameraCapture = CameraFeedManager(previewView: previewView)
@@ -791,18 +791,16 @@ extension ViewController {
 				} else {
 					self.lastLetter = prediction
 					print("reset count")
-					
+
 					self.recurCount = 0
 				}
 				if self.recurCount > 3 {
 					self.outputTextView.text += self.result!.inferences[0].label.description
 					self.recurCount = 0
-					
+
 				}
 			}
 		}
-		
+
 	}
 }
-
-


### PR DESCRIPTION
In this pool request I'm trying to increase the speed of inference of sign language letters. I've tested changing thread amounts and removing delays. I am also changing thresholds for number of reoccurrences needed to insert the letter into the textview. This code was heavily inspired by @viethphamvn Java code.

```swift
/// Function that checks the letter result from the model. If the prediction occurs more than the `reoccurenceConstant` the prediction is inserted into the TextView.
/// - Parameters:
///   - prediction: The topmost prediction from the model.
///   - confidence: The confidence value associated to the prediction.
fileprivate func checkConfidenceAndReoccurrenceOfLetter(_ prediction: String, _ confidence: Float) {
  if prediction == self.lastLetter && confidence > self.minimumConfidence {
    //					print(prediction)
    
    self.showPredictionLetterInStack(prediction, confidence, self.recurCount)
    
    self.recurCount += 1
  } else {
    self.lastLetter = prediction
    //					print("reset count")
    self.setPredictionToNothing()
    self.recurCount = 0
  }
  if self.recurCount > minimumReoccurence {
    self.target?.insertText(self.lastLetter!)
    self.recurCount = 0
    self.setPredictionToNothing()
  }
}
```